### PR TITLE
Fix for time series drill bug

### DIFF
--- a/eratos_xarray/backend/eratos_.py
+++ b/eratos_xarray/backend/eratos_.py
@@ -55,8 +55,8 @@ class EratosBackendArray(BackendArray):
                 strides.append(k.step if k.step else 1)
             elif isinstance(k, int):
                 starts.append(k)
-                ends.append(k)
-                strides.append(k)
+                ends.append(k+1)
+                strides.append(1)
 
         array = self.gdata.get_subset_as_array(self.var, starts, ends, strides)
 

--- a/eratos_xarray/backend/eratos_.py
+++ b/eratos_xarray/backend/eratos_.py
@@ -13,6 +13,7 @@ from xarray.backends.common import BACKEND_ENTRYPOINTS
 from xarray import Variable
 from xarray.core import indexing
 from xarray.core.utils import Frozen, FrozenDict, close_on_error
+from xarray.core.pycompat import integer_types
 from xarray.backends.common import AbstractDataStore, BackendArray, BackendEntrypoint
 
 
@@ -53,12 +54,19 @@ class EratosBackendArray(BackendArray):
                 starts.append(k.start if k.start else 0)
                 ends.append(k.stop if k.stop else default_stop)
                 strides.append(k.step if k.step else 1)
-            elif isinstance(k, int):
+            elif isinstance(k, integer_types):
                 starts.append(k)
                 ends.append(k+1)
                 strides.append(1)
 
         array = self.gdata.get_subset_as_array(self.var, starts, ends, strides)
+
+        # axis is a tuple, containing the index of each dimension selected by integer
+        axis = tuple(n for n, k in enumerate(key) if isinstance(k, integer_types))
+
+        # If the returned array hdoes not have the expected number of dimensions, then remove integer selected dimensions out.
+        if (array.ndim != self.ndim - len(axis)) and axis:
+            array = np.squeeze(array, axis)
 
         # TODO: how to properly handle missing values???
         # Currently Eratos SDK returns raw data arrays, and does not expose the missing vlaue metadata of underlying netcdf

--- a/tests/test_eratos_sdk.py
+++ b/tests/test_eratos_sdk.py
@@ -39,9 +39,9 @@ class EratosSDKITest(unittest.TestCase):
 
     def test_silo_time_drill(self):
         """
-                Open remote SILO dataset, slice to known spatial area.
-                :return:
-                """
+        Open remote SILO dataset, slice to known spatial area.
+        :return:
+        """
         # Import the backend module to ensure it is registered
         import eratos_xarray
 

--- a/tests/test_eratos_sdk.py
+++ b/tests/test_eratos_sdk.py
@@ -2,7 +2,7 @@ import unittest
 import os
 from eratos.creds import AccessTokenCreds
 import xarray as xr
-
+import numpy as np
 
 class EratosSDKITest(unittest.TestCase):
 
@@ -26,6 +26,33 @@ class EratosSDKITest(unittest.TestCase):
         # Import the backend module to ensure it is registered
         import eratos_xarray
 
-        silo = xr.open_dataset('ern:e-pn.io:resource:eratos.blocks.silo.maxtemperature', auth=self.ecreds)
+        silo = xr.open_dataset('ern:e-pn.io:resource:eratos.blocks.silo.maxtemperature', eratos_auth=self.ecreds)
         bars_silo = silo.sel(dict(lat=slice(-34.91, -34.02), lon=slice(148.03, 148.97))).sel(time=slice("2023-06-02", "2023-06-10"))
+
+        self.assertEqual(bars_silo['lat'][0], -34.9)
+        self.assertEqual(bars_silo['lat'][-1], -34.05)
+        self.assertEqual(bars_silo['lon'][0], 148.05)
+        self.assertEqual(bars_silo['lon'][-1], 148.95)
+        self.assertEqual(bars_silo['time'].data[0], np.datetime64('2023-06-02T00:00:00.000000000'))
+        self.assertEqual(bars_silo['time'].data[-1], np.datetime64('2023-06-10T00:00:00.000000000'))
         self.assertEqual((9, 18, 19), bars_silo['max_temp'].shape)
+
+    def test_silo_time_drill(self):
+        """
+                Open remote SILO dataset, slice to known spatial area.
+                :return:
+                """
+        # Import the backend module to ensure it is registered
+        import eratos_xarray
+
+        silo = xr.open_dataset('ern:e-pn.io:resource:eratos.blocks.silo.maxtemperature', eratos_auth=self.ecreds)
+        bars_silo = silo.sel(dict(lat=-34.91, lon=148.03), method='nearest').sel(time=slice("2023-06-02", "2023-06-10")).load()
+
+        self.assertEqual(bars_silo['lat'], -34.9)
+        self.assertEqual(bars_silo['lat'].shape, ())
+        self.assertEqual(bars_silo['lon'], 148.05)
+        self.assertEqual(bars_silo['lon'].shape, ())
+        self.assertEqual(bars_silo['time'].data[0], np.datetime64('2023-06-02T00:00:00.000000000'))
+        self.assertEqual(bars_silo['time'].data[-1], np.datetime64('2023-06-10T00:00:00.000000000'))
+
+        self.assertEqual(bars_silo['max_temp'].shape, (9, 1, 1))

--- a/tests/test_eratos_sdk.py
+++ b/tests/test_eratos_sdk.py
@@ -54,5 +54,8 @@ class EratosSDKITest(unittest.TestCase):
         self.assertEqual(bars_silo['lon'].shape, ())
         self.assertEqual(bars_silo['time'].data[0], np.datetime64('2023-06-02T00:00:00.000000000'))
         self.assertEqual(bars_silo['time'].data[-1], np.datetime64('2023-06-10T00:00:00.000000000'))
+        self.assertEqual(xr.core.formatting.first_n_items(bars_silo.max_temp, 1), 18.4)
+        self.assertEqual(bars_silo['max_temp'].shape, (9,))
+
 
         self.assertEqual(bars_silo['max_temp'].shape, (9, 1, 1))


### PR DESCRIPTION
The indexer was incorrectly setting the slicing `end` and `stride` parameters when exact (integer) index selection was being used.

This caused single coordinate slices to fail.

I've added a test of a time series drill on SILO grids.

Also, the argument for the eratos auth was incorrect in the tests.