### PR TITLE
chore: add pypi version of eratos-sdk as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ repository = "https://bitbucket.csiro.au/projects/SC/repos/eratos-xarray/browse"
 python = "^3.8, <3.12"
 xarray = "^2023.1.0"
 numpy = "^1.20.0"
-eratos = { url = "https://releases.eratos.com/sdk/python/eratos-python-latest.zip" }
+eratos-sdk = "^0.16.0"
 
 [tool.poetry.plugins."xarray.backends"]
 eratos = "eratos_xarray.backend.eratos_:EratosBackendEntrypoint"


### PR DESCRIPTION
Quick one just to add the pypi version of the sdk as a dependency to remove any pip related conflicts with existing environments.