### PR TITLE
Add more options to auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Xarray support for Eratos SDK
 
-Provides an Xarray backend for Eratos SDK (www.eratos.com). The backend supports lazy loading remote datasets.
+Provides an Xarray backend for Eratos SDK (<www.eratos.com>). The backend supports lazy loading remote datasets.
 
-### Getting Started
+## Usage
+
+Gridded datasets may be opened in `xarray` by passing in a valid ERN to the path argument and then supplying either an Eratos credentials object to `eratos_auth`
+or an Eratos adapter object to `eratos_adapter`.
 
 See below for a minimal example to open the SILO maximum temperature dataset.
 
@@ -10,14 +13,30 @@ See below for a minimal example to open the SILO maximum temperature dataset.
 
 from eratos.creds import AccessTokenCreds
 import xarray as xr
-import eratos_xarray
 
 eratos_id = 'ENTER YOUR ERATOS ID'
 eratos_secret = 'ENTER YOUR ERATOS SECRET KEY'
 
 ecreds = AccessTokenCreds(eratos_id, eratos_secret)
+silo = xr.open_dataset('ern:e-pn.io:resource:eratos.blocks.silo.maxtemperature', eratos_auth=ecreds)
 
-silo = xr.open_dataset('ern:e-pn.io:resource:eratos.blocks.silo.maxtemperature', auth=ecreds)
+print(silo)
+```
+
+alternatively an initialised adapter object can be passed through. This is useful to reuse the same session.
+
+```python
+
+from eratos.creds import AccessTokenCreds
+from eratos.adapter import Adapter
+import xarray as xr
+
+eratos_id = 'ENTER YOUR ERATOS ID'
+eratos_secret = 'ENTER YOUR ERATOS SECRET KEY'
+
+ecreds = AccessTokenCreds(eratos_id, eratos_secret)
+adapter = Adapter(ecreds)
+silo = xr.open_dataset('ern:e-pn.io:resource:eratos.blocks.silo.maxtemperature', eratos_adpater=adapter)
 
 print(silo)
 ```

--- a/eratos_xarray/backend/eratos_.py
+++ b/eratos_xarray/backend/eratos_.py
@@ -121,7 +121,6 @@ class EratosDataStore(AbstractDataStore):
         if eratos_adapter:
             adapter = eratos_adapter
         elif eratos_auth:
-            print(f"ignore_certs: {ignore_certs}")
             adapter = Adapter(eratos_auth, ignore_certs=ignore_certs)
         else:
             raise ValueError("Need Eratos creds or adapter object")

--- a/eratos_xarray/backend/eratos_.py
+++ b/eratos_xarray/backend/eratos_.py
@@ -4,10 +4,9 @@ import numpy as np
 from packaging import version
 
 from eratos.adapter import Adapter
-from eratos.creds import AccessTokenCreds
+from eratos.creds import BaseCreds
 from eratos.data import Data, GSData
 
-import xarray
 from xarray.backends import StoreBackendEntrypoint
 from xarray.backends.common import BACKEND_ENTRYPOINTS
 from xarray import Variable
@@ -15,6 +14,8 @@ from xarray.core import indexing
 from xarray.core.utils import Frozen, FrozenDict, close_on_error
 from xarray.core.pycompat import integer_types
 from xarray.backends.common import AbstractDataStore, BackendArray, BackendEntrypoint
+
+from typing import Optional
 
 
 class EratosBackendArray(BackendArray):
@@ -88,9 +89,16 @@ class EratosBackendEntrypoint(BackendEntrypoint):
         *,
         decode_times=True,
         drop_variables=None,
-        eratos_auth: AccessTokenCreds = None,
+        eratos_auth: Optional[BaseCreds] = None,
+        ignore_certs: bool = False,
+        eratos_adapter: Optional[Adapter] = None,
     ):
-        store = EratosDataStore.open(ern=filename_or_obj, eratos_auth=eratos_auth)
+        store = EratosDataStore.open(
+            ern=filename_or_obj,
+            eratos_auth=eratos_auth,
+            ignore_certs=ignore_certs,
+            eratos_adapter=eratos_adapter,
+        )
 
         store_entrypoint = StoreBackendEntrypoint()
         with close_on_error(store):
@@ -103,8 +111,20 @@ class EratosDataStore(AbstractDataStore):
         self.gsdata = gsdata
 
     @classmethod
-    def open(cls, ern, eratos_auth: AccessTokenCreds = None):
-        adapter = Adapter(eratos_auth)
+    def open(
+        cls,
+        ern,
+        eratos_auth: Optional[BaseCreds] = None,
+        ignore_certs: bool = False,
+        eratos_adapter: Optional[Adapter] = None,
+    ):
+        if eratos_adapter:
+            adapter = eratos_adapter
+        elif eratos_auth:
+            print(f"ignore_certs: {ignore_certs}")
+            adapter = Adapter(eratos_auth, ignore_certs=ignore_certs)
+        else:
+            raise ValueError("Need Eratos creds or adapter object")
         resource = adapter.Resource(ern=ern)
         data: Data = resource.data()
         gsdata: GSData = data.gapi()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eratos-xarray"
-version = "0.1.6"
+version = "0.1.7"
 description = "Xarray backend for Eratos SDK"
 authors = ["Chris Sharman <chris.sharman@csiro.au>"]
 readme = "README.md"


### PR DESCRIPTION
This makes it more convenient to use `eratos_xarray` by allowing the user to pass in their own adapter object. In the way that Eratos operators are currently created, only an `eratos.Adapter` object is accessible. Although there is a hacky way to retrieve the credentials, it's easier if we can just pass it directly into `xr.open_dataset`. 

I've also added the option to disable SSL verification. We would use this if we were to run the Eratos platform APIs locally on our machine. 