### PR TITLE
chore: allow minor version increments until v1 of sdk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eratos-xarray"
-version = "0.1.7"
+version = "0.1.8"
 description = "Xarray backend for Eratos SDK"
 authors = ["Chris Sharman <chris.sharman@csiro.au>"]
 readme = "README.md"
@@ -10,10 +10,10 @@ homepage = "https://bitbucket.csiro.au/projects/SC/repos/eratos-xarray/browse"
 repository = "https://bitbucket.csiro.au/projects/SC/repos/eratos-xarray/browse"
 
 [tool.poetry.dependencies]
-python = "^3.8, <3.12"
+python = "^3.8"
 xarray = "^2023.1.0"
 numpy = "^1.20.0"
-eratos-sdk = "^0.16.0"
+eratos-sdk = ">=0.16.0,<1.0.0"
 
 [tool.poetry.plugins."xarray.backends"]
 eratos = "eratos_xarray.backend.eratos_:EratosBackendEntrypoint"


### PR DESCRIPTION
Fixing issues with sdk, the previous pinning method did not allow for minor increments of the SDK which meant that pip would not resolve any newer minor versions from 0.16.x onwards. This new way allows for all version increments up to a v1 of the SDK.

Also removing the cap on python 2.12. Tested on side effects for 3.12 and 3.13 versions of python