### PR TITLE
support for fill value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+### [v0.1.9] - 2025-07-04
+
+- Fill values returned by the gridded data interface will now be passed into [`xarray.Variable`](https://docs.xarray.dev/en/stable/generated/xarray.Variable.html) via the `encoding` and `attrs` properties.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-### [v0.1.9] - 2025-07-04
+### [v0.2.0] - 2025-07-04
 
 - Fill values returned by the gridded data interface will now be passed into [`xarray.Variable`](https://docs.xarray.dev/en/stable/generated/xarray.Variable.html) via the `encoding` and `attrs` properties.

--- a/eratos_xarray/backend/eratos_.py
+++ b/eratos_xarray/backend/eratos_.py
@@ -141,6 +141,7 @@ class EratosDataStore(AbstractDataStore):
         if fill_val:
             # attrs["_FillValue"] = fill_val
             encoding = {"_FillValue": fill_val}
+            attrs['missing_value'] = fill_val
 
         return Variable(dimensions, data, attrs, encoding=encoding)
 

--- a/eratos_xarray/backend/eratos_.py
+++ b/eratos_xarray/backend/eratos_.py
@@ -29,7 +29,6 @@ class EratosBackendArray(BackendArray):
             self.shape = self.shape + (self.all_dimensions[dim_name]["size"],)
 
         self.dtype = np.dtype(gdata.variables()[var]["dataType"])
-        self.fill_value = gdata.variables()[var]["fillValue"]
 
     def __getitem__(self, key: indexing.ExplicitIndexer) -> np.typing.ArrayLike:
         return indexing.explicit_indexing_adapter(
@@ -137,7 +136,7 @@ class EratosDataStore(AbstractDataStore):
 
         # Leverage Xarray cf time decoder as all 'time' variable responses are treated as unix time.
         attrs = {"units": "seconds since 1970-01-01 00:00:00"} if var == "time" else {}
-        fill_val = self.gsdata.variables()[var]["fillValue"]
+        fill_val = self.gsdata.variables()[var].get("fillValue", None)
         encoding = None
         if fill_val:
             # attrs["_FillValue"] = fill_val

--- a/eratos_xarray/backend/eratos_.py
+++ b/eratos_xarray/backend/eratos_.py
@@ -139,7 +139,6 @@ class EratosDataStore(AbstractDataStore):
         fill_val = self.gsdata.variables()[var].get("fillValue", None)
         encoding = None
         if fill_val:
-            # attrs["_FillValue"] = fill_val
             encoding = {"_FillValue": fill_val}
             attrs['missing_value'] = fill_val
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eratos-xarray"
-version = "0.1.8"
+version = "0.2.0"
 description = "Xarray backend for Eratos SDK"
 authors = ["Chris Sharman <chris.sharman@csiro.au>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ repository = "https://bitbucket.csiro.au/projects/SC/repos/eratos-xarray/browse"
 python = "^3.8"
 xarray = "^2023.1.0"
 numpy = "^1.20.0"
-eratos-sdk = "^0.17.0"
+eratos-sdk = ">=0.16.0,<1.0.0"
 
 [tool.poetry.plugins."xarray.backends"]
 eratos = "eratos_xarray.backend.eratos_:EratosBackendEntrypoint"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ repository = "https://bitbucket.csiro.au/projects/SC/repos/eratos-xarray/browse"
 python = "^3.8"
 xarray = "^2023.1.0"
 numpy = "^1.20.0"
-eratos-sdk = ">=0.16.0,<1.0.0"
+eratos-sdk = ">=0.18.0,<1.0.0"
 
 [tool.poetry.plugins."xarray.backends"]
 eratos = "eratos_xarray.backend.eratos_:EratosBackendEntrypoint"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ repository = "https://bitbucket.csiro.au/projects/SC/repos/eratos-xarray/browse"
 python = "^3.8"
 xarray = "^2023.1.0"
 numpy = "^1.20.0"
-eratos-sdk = ">=0.16.0,<1.0.0"
+eratos-sdk = "^0.17.0"
 
 [tool.poetry.plugins."xarray.backends"]
 eratos = "eratos_xarray.backend.eratos_:EratosBackendEntrypoint"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,162 @@
+import os
+from uuid import uuid4
+import warnings
+import string
+import random
+
+import pytest
+import numpy as np
+import xarray as xr
+
+from eratos.creds import AccessTokenCreds
+from eratos.adapter import Adapter
+from eratos.errors import CommError
+from eratos.dsutil.netcdf import _MAX_FLOAT64_PRECISION
+
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+KEY = os.getenv("ERATOS_KEY")
+SECRET = os.getenv("ERATOS_SECRET")
+
+LOCAL_DEV_KEY = "7VRRBYBMQCHMJW2KMUE4Q4GY"
+LOCAL_DEV_SECRET = "6kS98wDY9mMfaZwZ5wxzvRbO5PxPzoU5Eh59bruYvAE="
+USE_ERATOS_PLATFORM_LOCALHOST = int(os.getenv("USE_ERATOS_PLATFORM_LOCALHOST", "0"))
+
+NO_ERATOS_PLATFORM = (not KEY or not SECRET) and not USE_ERATOS_PLATFORM_LOCALHOST
+
+
+@pytest.fixture
+def get_sample_netcdf_missing_vals():
+    def _method(start_date: np.datetime64, end_date: np.datetime64, data_type: str):
+        lat_size = 5
+        lon_size = 5
+        dates = np.arange(
+            start_date,
+            end_date,
+            dtype="datetime64[D]",
+        )
+        shape = (dates.shape[0], lat_size, lon_size)
+        num_type = data_type[0]
+        match data_type:
+            case "u1" | "u2" | "u4" | "u8":
+                info = np.iinfo(data_type)
+                fill = np.random.randint(0, min(info.max, _MAX_FLOAT64_PRECISION))
+                fill = np.array(fill, dtype=data_type).item()
+                vals = np.random.randint(0, info.max, size=shape, dtype=data_type)
+                vals = np.where(vals == fill, (fill + 1) % (info.max + 1), vals)
+
+            case "i2" | "i4" | "i8":
+                info = np.iinfo(data_type)
+                fill = np.random.randint(
+                    max(info.min, -1 * _MAX_FLOAT64_PRECISION),
+                    min(info.max, _MAX_FLOAT64_PRECISION),
+                )
+                fill = np.array(fill, dtype=data_type).item()
+                vals = np.random.randint(
+                    max(info.min, -1 * _MAX_FLOAT64_PRECISION),
+                    min(info.max, _MAX_FLOAT64_PRECISION),
+                    size=shape,
+                    dtype=data_type,
+                )
+                vals = np.where(vals == fill, fill + 1, vals)
+
+            case "f4" | "f8":
+                fill = np.random.uniform(-99, 99)
+                fill = np.array(fill, dtype=data_type).item()
+                vals = np.random.uniform(-99, 99, size=shape).astype(data_type)
+                # optionally mask fill value
+                vals = np.where(vals == fill, fill + 0.1, vals)
+
+            case "c8" | "c16":
+                fill = np.random.uniform(-99, 99) + np.random.uniform(0, 1) * 1j
+                fill = np.array(fill, dtype=data_type).item()
+                vals = (
+                    np.random.uniform(-99, 99, size=shape)
+                    + np.random.uniform(0, 1, size=shape) * 1j
+                ).astype(data_type)
+                # skip replacing fill — complex comparisons are tricky; may add a tolerance if needed
+
+            case _:
+                raise ValueError(f"Unsupported num_type: {num_type}")
+
+        mask = np.random.choice(a=[0, 1], size=shape, p=[0.6, 0.4])
+
+        ds = xr.Dataset(
+            data_vars={
+                "blah": (
+                    ["time", "lat", "lon"],
+                    np.where(mask, fill, vals),
+                )
+            },
+            coords={
+                "lat": ("lat", np.linspace(-34, -33, lat_size)),
+                "lon": ("lon", np.linspace(143, 144, lon_size)),
+                "time": ("time", dates),
+            },
+        )
+        # cursed casting into type
+        ds.variables["blah"].encoding["_FillValue"] = fill
+
+        return ds
+
+    return _method
+
+
+@pytest.fixture(scope="session")
+def adapter():
+    if NO_ERATOS_PLATFORM:
+        warnings.warn(
+            "No Eratos platform integration - set ERATOS_KEY and ERATOS_SECRET environment variables"
+        )
+        return None
+        # so other tests don't break
+        raise ValueError(
+            "No Eratos platform integration - set ERATOS_KEY and ERATOS_SECRET environment variables"
+        )
+    if USE_ERATOS_PLATFORM_LOCALHOST:
+        print("Using localhost platform")
+        ecreds = AccessTokenCreds(
+            LOCAL_DEV_KEY, LOCAL_DEV_SECRET, "https://localhost:11080"
+        )
+        return Adapter(ecreds, ignore_certs=True)
+
+    ecreds = AccessTokenCreds(KEY, SECRET, tracker="https://dev.e-tr.io")
+    return Adapter(ecreds)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def namespace(adapter):
+    # random string for namespace here
+    letters = string.ascii_lowercase
+    namespace_id = "".join([random.choice(letters) for _ in range(8)])
+    if adapter is None:
+        yield None
+    else:
+        try:
+            print("Creating namespace for integration test")
+            ns = adapter.Resource(
+                content={
+                    "@type": "ern:e-pn.io:schema:namespace",
+                    "key": namespace_id,
+                    "name": f"Eratos Integration Test Namespace",
+                    "description": f"Eratos Integration Test Namespace",
+                }
+            ).save()
+            print(f"Created namespace: {namespace_id}")
+            yield namespace_id
+        except CommError as e:
+            if e.code != 4006:
+                raise
+        finally:
+            print("Removing temporary namespace for integration test.")
+            ns.remove()
+
+
+@pytest.fixture
+def node_ern():
+    if USE_ERATOS_PLATFORM_LOCALHOST:
+        return "ern::node:test-cluster"
+    else:
+        return "ern::node:au-1.e-gn.io"

--- a/tests/test_upload_read.py
+++ b/tests/test_upload_read.py
@@ -1,0 +1,56 @@
+import pytest
+from .conftest import KEY, NO_ERATOS_PLATFORM, SECRET, USE_ERATOS_PLATFORM_LOCALHOST
+from dotenv import load_dotenv
+import xarray as xr
+import numpy as np
+
+from pathlib import Path
+
+from eratos.dsutil import netcdf
+from eratos.data import Data
+from eratos.dsutil.netcdf import _DEFAULT_FILL
+
+
+@pytest.mark.parametrize(
+    "dtype", ["f4", "f8", "u1", "u2", "u4", "u8", "i2", "i4", "i8"]
+)
+@pytest.mark.skipif(NO_ERATOS_PLATFORM, reason="No Eratos platform integration.")
+def test_fillvalues(
+    adapter, namespace, node_ern, dtype, tmp_path, get_sample_netcdf_missing_vals
+):
+    ds = get_sample_netcdf_missing_vals(
+        np.datetime64("2025-01-01"), np.datetime64("2025-01-03"), data_type=dtype
+    )
+    fill = ds.variables["blah"].encoding["_FillValue"]
+    print(f"Generated dataset fill: {fill}")
+    print(f"Generated dataset dtype: {ds.variables['blah'].dtype}")
+    print(f"Using default return fill value: {_DEFAULT_FILL[dtype]}")
+
+    file_path = (tmp_path / "sample.nc").as_posix()
+    ds.to_netcdf(file_path)
+    fmap = {"sample.nc": file_path}
+    connector_props = netcdf.gridded_geotime_netcdf_props({"sample.nc": file_path})
+    ern = f"ern:e-pn.io:resource:{namespace}.tests.{dtype}-fillvalue-test"
+    res = adapter.Resource(
+        content={
+            "@id": ern,
+            "@type": "ern:e-pn.io:schema:dataset",
+            "description": "Integration test - fill value",
+            "type": "ern:e-pn.io:resource:eratos.dataset.type.gridded",
+            "updateSchedule": "ern:e-pn.io:resource:eratos.schedule.noupdate",
+            "name": "Integration test fill value",
+        }
+    )
+    res.save()
+
+    data = res.data()
+    data.push_objects(node_ern, fmap, Data.GRIDDED_V1, connector_props)
+
+    ds_returned = xr.open_dataset(ern, engine="eratos", eratos_adapter=adapter)
+    # check fill value is equal
+    assert ds_returned.variables["blah"].encoding["_FillValue"] == _DEFAULT_FILL[dtype]
+
+    # check xarray mask method works properly
+    ds_returned.load(mask_and_scale=True)
+    mask = ds.variables["blah"].values == fill
+    assert np.all(np.isnan(ds_returned["blah"].values[mask]))


### PR DESCRIPTION
Added support for fill value based on -
- https://github.com/eratosio/python-sdk/pull/30
- https://github.com/eratosio/eratos-platform/pull/84

If fill value is non null for a variable, then it adds the fill value metadata via `xarray.Variable.encoding`. This doesn't automatically turn the fill values into `nan` but it does provide an indication as to what it is, and if the dataset is loaded and written out using `to_netcdf`, it will contain the fill value in the variable metadata. With `xarray.Dataset.load(mask_and_scale=True)`, `xarray` will automatically replace the fill values with `np.nan`.